### PR TITLE
Made 'webhookEvent' key optional

### DIFF
--- a/jira_rabbitmq_webhook/application.py
+++ b/jira_rabbitmq_webhook/application.py
@@ -54,8 +54,11 @@ class JRWApplication:
 
         content = await request.content.read()
         data = loads(content)
-        event = data['webhookEvent']
-        queue = self.queues.get(event, self.default_queue)
+        if 'webhookEvent' in data:
+            event = data['webhookEvent']
+            queue = self.queues.get(event, self.default_queue)
+        else:
+            queue = self.default_queue
         await channel.publish(content, '', queue, {'delivery_mode': 2})
 
         return web.Response()


### PR DESCRIPTION
Hooks triggered as workflow post functions don't contain the 'webhookEvent' key. With this change jira_rabbitmq_webhook works for workflow webhooks as well as issue created/updated/deleted webhooks.